### PR TITLE
Fix depedency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "symfony/symfony": ">=2.4",
-        "simplesamlphp/simplesamlphp": "~1.13"
+        "simplesamlphp/simplesamlphp": "dev-master"
     },
     "autoload": {
         "psr-4": { "Hslavich\\SimplesamlphpBundle\\": "" }


### PR DESCRIPTION
[simplesamlphp 1.32.2 has a dependency issue with openid/php-openid](https://github.com/simplesamlphp/simplesamlphp/issues/249), which is fixed in the current master. So until the next release, this bundle needs to require the `dev-master` of simplesamlphp.
