### PR TITLE
Fixed deprecation issues

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,8 +5,8 @@ services:
 
     simplesamlphp.authenticator:
         class: Hslavich\SimplesamlphpBundle\Security\SamlAuthenticator
-        arguments: [ @simplesamlphp.auth, @session, %simplesamlphp.auth_attribute% ]
+        arguments: [ '@simplesamlphp.auth', '@session', %simplesamlphp.auth_attribute% ]
 
     simplesamlphp.logout_handler:
         class: Hslavich\SimplesamlphpBundle\Security\Http\Logout\LogoutSuccessHandler
-        arguments: [ @simplesamlphp.auth, @router ]
+        arguments: [ '@simplesamlphp.auth', '@router' ]

--- a/Security/SamlAuthenticator.php
+++ b/Security/SamlAuthenticator.php
@@ -5,7 +5,7 @@ namespace Hslavich\SimplesamlphpBundle\Security;
 use Hslavich\SimplesamlphpBundle\Security\Core\Authentication\Token\SamlToken;
 use Hslavich\SimplesamlphpBundle\Security\Core\User\SamlUserInterface;
 use Hslavich\SimplesamlphpBundle\Exception\MissingSamlAuthAttributeException;
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">=2.4",
+        "symfony/symfony": ">=2.8",
         "simplesamlphp/simplesamlphp": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Fixed various issues which are deprecated in Symfony >= 2.8 and cause exceptions in Symfony 3.0.

As a side effect this causes the min. supported Symfony version to be at least 2.8. You could consider to have separate branches for different Symfony versions.
