### PR TITLE
Fixed deprecation issues

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,11 +1,11 @@
 services:
     simplesamlphp.auth:
         class: SimpleSAML_Auth_Simple
-        arguments: [ %simplesamlphp.sp% ]
+        arguments: [ '%simplesamlphp.sp%' ]
 
     simplesamlphp.authenticator:
         class: Hslavich\SimplesamlphpBundle\Security\SamlAuthenticator
-        arguments: [ '@simplesamlphp.auth', '@session', %simplesamlphp.auth_attribute% ]
+        arguments: [ '@simplesamlphp.auth', '@session', '%simplesamlphp.auth_attribute%' ]
 
     simplesamlphp.logout_handler:
         class: Hslavich\SimplesamlphpBundle\Security\Http\Logout\LogoutSuccessHandler


### PR DESCRIPTION
`Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0`
